### PR TITLE
Person Request Data Filtering Serialization Fix

### DIFF
--- a/fc/person_request.go
+++ b/fc/person_request.go
@@ -5,7 +5,7 @@ type PersonRequestOption func(pr *PersonRequest)
 type PersonRequest struct {
 	Emails     []string    `json:"emails,omitempty"`
 	Phones     []string    `json:"phones,omitempty"`
-	DataFilter []string    `json:"dataFilters,omitempty"`
+	DataFilter []string    `json:"dataFilter,omitempty"`
 	Maid       []string    `json:"maids,omitempty"`
 	Location   *Location   `json:"location,omitempty"`
 	Name       *PersonName `json:"name,omitempty"`


### PR DESCRIPTION
Specifying `fc.WithDataFilter()` previously did not correctly serialize the request, causing more data to be returned than requested.