### PR TITLE
Add ability to use a custom http client

### DIFF
--- a/fc/client.go
+++ b/fc/client.go
@@ -39,8 +39,11 @@ func NewFullContactClient(options ...ClientOption) (*fullContactClient, error) {
 	if c.retryHandler == nil {
 		c.retryHandler = &DefaultRetryHandler{}
 	}
-	c.httpClient = &http.Client{
-		Timeout: time.Duration(c.connectTimeoutMillis) * time.Millisecond,
+
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{
+			Timeout: time.Duration(c.connectTimeoutMillis) * time.Millisecond,
+		}
 	}
 
 	return c, nil
@@ -69,5 +72,11 @@ func WithHeaders(headers map[string]string) ClientOption {
 func WithRetryHandler(retryHandler RetryHandler) ClientOption {
 	return func(fc *fullContactClient) {
 		fc.retryHandler = retryHandler
+	}
+}
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(fc *fullContactClient) {
+		fc.httpClient = httpClient
 	}
 }


### PR DESCRIPTION
## Summary

Add the ability to use a custom http client.

## Description

We use `go-vcr` (https://github.com/dnaeon/go-vcr) to record HTTP calls to FullContact and replay them in our unit tests. The go-vcr package requires us to use a custom HTTP `Transport` to hook in and record the calls and responses, but the `fullcontact-go` client does not currently allow us to set this. 

To remedy this, we added a new `WithHTTPClient` function, similar to the existing `WithCredentialsProvider`/`WithTimeout`/`WithHeaders`, etc functions which allows us to use our own HTTP client.