### PR TITLE
Change CredentialsProvider to require an exported method

### DIFF
--- a/fc/credentials_provider.go
+++ b/fc/credentials_provider.go
@@ -3,7 +3,7 @@ package fullcontact
 import "os"
 
 type CredentialsProvider interface {
-	getApiKey() string
+	GetApiKey() string
 }
 
 type StaticCredentialsProvider struct {
@@ -18,7 +18,7 @@ func NewStaticCredentialsProvider(apiKey string) (StaticCredentialsProvider, err
 	}
 }
 
-func (scp StaticCredentialsProvider) getApiKey() string {
+func (scp StaticCredentialsProvider) GetApiKey() string {
 	return scp.apiKey
 }
 
@@ -35,6 +35,6 @@ func NewDefaultCredentialsProvider(envVar string) (DefaultCredentialsProvider, e
 	}
 }
 
-func (dcp DefaultCredentialsProvider) getApiKey() string {
+func (dcp DefaultCredentialsProvider) GetApiKey() string {
 	return dcp.apiKey
 }

--- a/fc/credentials_provider_test.go
+++ b/fc/credentials_provider_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewStaticCredentialsProvider(t *testing.T) {
 	cp, err := NewStaticCredentialsProvider("apikey")
 	assert.NoError(t, err)
-	assert.Equal(t, "apikey", cp.getApiKey())
+	assert.Equal(t, "apikey", cp.GetApiKey())
 }
 
 func TestNewStaticCredentialsProviderWithEmptyKey(t *testing.T) {
@@ -23,7 +23,7 @@ func TestNewDefaultCredentialsProvider(t *testing.T) {
 	if err != nil {
 		cp, err := NewDefaultCredentialsProvider(FcApiKey)
 		assert.NoError(t, err)
-		assert.Equal(t, "apikey", cp.getApiKey())
+		assert.Equal(t, "apikey", cp.GetApiKey())
 	}
 }
 

--- a/fc/fullcontact.go
+++ b/fc/fullcontact.go
@@ -35,7 +35,7 @@ func (fcClient *fullContactClient) addHeaders(req *http.Request) *http.Request {
 	for k, v := range fcClient.headers {
 		req.Header.Add(k, v)
 	}
-	req.Header.Add("Authorization", "Bearer "+fcClient.credentialsProvider.getApiKey())
+	req.Header.Add("Authorization", "Bearer "+fcClient.credentialsProvider.GetApiKey())
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", userAgent)
 	return req


### PR DESCRIPTION
I believe this will resolve https://github.com/fullcontact/fullcontact-go/issues/20 

* `CredentialsProvider` now requires a method of `GetApiKey` rather than `getApiKey` and can be satisfied by implementations outside of this library
* The two implementations in this library (`DefaultCredentialsProvider` and `StaticCredentialsProvider`) have been changed to continue to satisfy the interface
* Because the interface was only satisfiable by these internal implementations and their unexported methods, I think this is a non-breaking change