### PR TITLE
Fix response parsing - missing or changed names

### DIFF
--- a/fc/household.go
+++ b/fc/household.go
@@ -42,7 +42,7 @@ type LocationInfo struct {
 }
 
 type FamilyInfo struct {
-	TotalAdults            int `json:"totalAdults"`
-	TotalChildren          int `json:"totalChildren"`
-	TotalPeopleInHousehold int `json:"totalPeopleInHousehold"`
+	TotalAdults            int    `json:"totalAdults"`
+	NumberOfChildren       string `json:"numberOfChildren"`
+	TotalPeopleInHousehold int    `json:"totalPeopleInHousehold"`
 }

--- a/fc/household.go
+++ b/fc/household.go
@@ -13,6 +13,7 @@ type HomeInfo struct {
 	LoanToValueEstimate int    `json:"loanToValueEstimate"`
 	YearsInHome         int    `json:"yearsInHome"`
 	DwellingType        string `json:"dwellingType"`
+	OwnerOrRenter       string `json:"ownerOrRenter"`
 }
 
 type Presence struct {

--- a/fc/household.go
+++ b/fc/household.go
@@ -21,7 +21,7 @@ type Presence struct {
 }
 
 type Finance struct {
-	Income                         string `json:"income"`
+	HouseholdIncomeEstimate        string `json:"householdIncomeEstimate"`
 	DiscretionarySpendingIncome    string `json:"discretionarySpendingIncome"`
 	FirstMortgageAmountInThousands string `json:"firstMortgageAmountInThousands"`
 	HomeMarketValueTaxRecord       string `json:"homeMarketValueTaxRecord"`

--- a/fc/household.go
+++ b/fc/household.go
@@ -26,7 +26,7 @@ type Finance struct {
 	FirstMortgageAmountInThousands string `json:"firstMortgageAmountInThousands"`
 	HomeMarketValueTaxRecord       string `json:"homeMarketValueTaxRecord"`
 	ShortTermLiability             string `json:"shortTermLiability"`
-	NetWorth                       string `json:"netWorth"`
+	NetWorthRange                  string `json:"netWorthRange"`
 	WealthResources                string `json:"wealthResources"`
 	PaymentMethodCreditCard        string `json:"paymentMethodCreditCard"`
 }

--- a/fc/person.go
+++ b/fc/person.go
@@ -50,6 +50,7 @@ type Demographics struct {
 	Occupation    string `json:"occupation"`
 	LivingStatus  string `json:"livingStatus"`
 	Age           Age    `json:"age"`
+	Language      string `json:"language"`
 }
 
 type Email struct {

--- a/fc/person_test.go
+++ b/fc/person_test.go
@@ -67,6 +67,7 @@ func TestPersonEnrich(t *testing.T) {
 
 	assert.Equal(t, "Probable Homeowner", response.Details.Demographics.LivingStatus)
 	assert.Equal(t, "Professional - Engineer/Industrial", response.Details.Demographics.Occupation)
+	assert.Equal(t, "English", response.Details.Demographics.Language)
 	assert.Equal(t, 145, response.Details.Census.BasicTractNumber)
 	assert.Equal(t, 2, response.Details.Census.BasicBlockGroup)
 	assert.Equal(t, "High School Diploma", response.Details.Census.Year2010.EducationLevel)

--- a/fc/person_test.go
+++ b/fc/person_test.go
@@ -45,6 +45,7 @@ func TestPersonEnrich(t *testing.T) {
 	assert.Equal(t, "Multi Family Dwelling/Apartment", response.Details.Household.HomeInfo.DwellingType)
 	assert.Equal(t, 513, response.Details.Household.HomeInfo.HomeValueEstimate)
 	assert.Equal(t, 4, response.Details.Household.HomeInfo.LoanToValueEstimate)
+	assert.Equal(t, "O", response.Details.Household.HomeInfo.OwnerOrRenter)
 	assert.True(t, response.Details.Household.LocationInfo.SeasonalAddress)
 	assert.Equal(t, "PO Box", response.Details.Household.LocationInfo.CarrierRoute)
 	assert.Equal(t, "807", response.Details.Household.LocationInfo.DesignatedMarketArea)

--- a/fc/person_test.go
+++ b/fc/person_test.go
@@ -55,7 +55,7 @@ func TestPersonEnrich(t *testing.T) {
 	assert.Equal(t, "Y", response.Details.Household.Presence.PresenceOfChildren)
 
 	// Finance
-	assert.Equal(t, "$30,000 - $39,999", response.Details.Household.Finance.Income)
+	assert.Equal(t, "$30,000 - $39,999", response.Details.Household.Finance.HouseholdIncomeEstimate)
 	assert.Equal(t, "$65,000 - $74,999", response.Details.Household.Finance.DiscretionarySpendingIncome)
 	assert.Equal(t, "5147", response.Details.Household.Finance.FirstMortgageAmountInThousands)
 	assert.Equal(t, "453", response.Details.Household.Finance.HomeMarketValueTaxRecord)

--- a/fc/person_test.go
+++ b/fc/person_test.go
@@ -40,7 +40,7 @@ func TestPersonEnrich(t *testing.T) {
 	assert.Equal(t, 42, response.Details.Age.Value)
 	assert.Equal(t, "Female", response.Details.Gender)
 	assert.Equal(t, 2, response.Details.Household.FamilyInfo.TotalAdults)
-	assert.Equal(t, 1, response.Details.Household.FamilyInfo.TotalChildren)
+	assert.Equal(t, "Less Than 3", response.Details.Household.FamilyInfo.NumberOfChildren)
 	assert.Equal(t, 3, response.Details.Household.FamilyInfo.TotalPeopleInHousehold)
 	assert.Equal(t, "Multi Family Dwelling/Apartment", response.Details.Household.HomeInfo.DwellingType)
 	assert.Equal(t, 513, response.Details.Household.HomeInfo.HomeValueEstimate)

--- a/fc/person_test.go
+++ b/fc/person_test.go
@@ -60,7 +60,7 @@ func TestPersonEnrich(t *testing.T) {
 	assert.Equal(t, "5147", response.Details.Household.Finance.FirstMortgageAmountInThousands)
 	assert.Equal(t, "453", response.Details.Household.Finance.HomeMarketValueTaxRecord)
 	assert.Equal(t, "$50,000 or more", response.Details.Household.Finance.ShortTermLiability)
-	assert.Equal(t, "$150,000 - $249,999", response.Details.Household.Finance.NetWorth)
+	assert.Equal(t, "$150,000 - $249,999", response.Details.Household.Finance.NetWorthRange)
 	assert.Equal(t, "$250,000 - $499,999", response.Details.Household.Finance.WealthResources)
 	assert.Equal(t, "Y", response.Details.Household.Finance.PaymentMethodCreditCard)
 

--- a/fc/person_test.json
+++ b/fc/person_test.json
@@ -25,7 +25,7 @@
     "household": {
       "familyInfo": {
         "totalAdults": 2,
-        "totalChildren": 1,
+        "numberOfChildren": "Less Than 3",
         "totalPeopleInHousehold": 3
       },
       "homeInfo": {

--- a/fc/person_test.json
+++ b/fc/person_test.json
@@ -31,7 +31,8 @@
       "homeInfo": {
         "dwellingType": "Multi Family Dwelling/Apartment",
         "homeValueEstimate": 513,
-        "loanToValueEstimate": 4
+        "loanToValueEstimate": 4,
+        "ownerOrRenter": "O"
       },
       "locationInfo": {
         "seasonalAddress": true,

--- a/fc/person_test.json
+++ b/fc/person_test.json
@@ -47,7 +47,7 @@
         "presenceOfChildren": "Y"
       },
       "finance" : {
-        "income" : "$30,000 - $39,999",
+        "householdIncomeEstimate" : "$30,000 - $39,999",
         "discretionarySpendingIncome" : "$65,000 - $74,999",
         "firstMortgageAmountInThousands" : "5147",
         "homeMarketValueTaxRecord" : "453",

--- a/fc/person_test.json
+++ b/fc/person_test.json
@@ -52,7 +52,7 @@
         "firstMortgageAmountInThousands" : "5147",
         "homeMarketValueTaxRecord" : "453",
         "shortTermLiability" : "$50,000 or more",
-        "netWorth" : "$150,000 - $249,999",
+        "netWorthRange" : "$150,000 - $249,999",
         "wealthResources" : "$250,000 - $499,999",
         "paymentMethodCreditCard" : "Y"
       }

--- a/fc/person_test.json
+++ b/fc/person_test.json
@@ -64,6 +64,7 @@
         "range": "35-44",
         "value": 42
       },
+      "language": "English",
       "livingStatus": "Probable Homeowner",
       "maritalStatus": "MARRIED",
       "occupation": "Professional - Engineer/Industrial"


### PR DESCRIPTION
There are some fields in JSON being returned that seem to be using different (possibly old?) names, or which are absent from this library entirely. I've fixed the ones I've seen here.

`income` => `householdIncomeEstimate`
`netWorth` => `netWorthRange`
`ownerOrRenter` (missing)
`language` (missing)
`totalChildren` => `numberOfChildren` and changed from an `int` to a `string` to match respnses like "Less Than 3"

At least a partial fix for #23.